### PR TITLE
AlmostDistributions v0.1.0 updated version

### DIFF
--- a/packages-extra.xml
+++ b/packages-extra.xml
@@ -241,7 +241,7 @@
 	url="https://github.com/rbouckaert/AlmostDistributions/releases/download/v0.1.0/AlmostDistribution.addon.v0.1.0.zip"
 	description="Almost-distributions"
 	projectURL="https://github.com/rbouckaert/AlmostDistributions">
-	<depends on='beast2' atleast='2.6.0' atmost='2.6.0'/>
+	<depends on='beast2' atleast='2.6.0' atmost='2.6.9'/>
 	<depends on='BEASTLabs' atleast='1.9.0'/>
     </package>
 	     


### PR DESCRIPTION
Update AlmostDistributions v0.1.0 to depend on BEAST v2.6.0 to v2.6.9