### PR TITLE
timtam v0.3.1

### DIFF
--- a/packages2.6.xml
+++ b/packages2.6.xml
@@ -1109,8 +1109,8 @@
 
     <package
         name="timtam"
-        version="0.3.0"
-	      url="https://github.com/aezarebski/timtam2/releases/download/v0.3.0/timtam.v0.3.0.zip"
+        version="0.3.1"
+	      url="https://github.com/aezarebski/timtam2/releases/download/v0.3.1/timtam.v0.3.1.zip"
 	      projectURL="https://aezarebski.github.io/timtam/index.html"
 	      description="Distribution for birth-death models with occurrence data and population size estimation.">
 	    <depends on="beast2" atleast="2.6.6" atmost="2.6.9"/>

--- a/packages2.6.xml
+++ b/packages2.6.xml
@@ -1106,4 +1106,13 @@
         <depends on="feast" atleast="7.5.3"/>
         <depends on="BEASTLabs" atleast="1.9.0"/>
     </package>
+
+    <package
+        name="timtam"
+        version="0.3.0"
+	      url="https://github.com/aezarebski/timtam2/releases/download/v0.3.0/timtam.v0.3.0.zip"
+	      projectURL="https://aezarebski.github.io/timtam/index.html"
+	      description="Distribution for birth-death models with occurrence data and population size estimation.">
+	    <depends on="beast2" atleast="2.6.6" atmost="2.6.9"/>
+    </package>
 </packages>


### PR DESCRIPTION
reference updated version of timtam which does not have extra cruft in the lib directory and has safer ids in the templates.