### PR TITLE
removed SpeciesNetwork v0.12.2

### DIFF
--- a/packages2.6.xml
+++ b/packages2.6.xml
@@ -244,12 +244,6 @@
         <depends on='BEASTLabs' atleast='1.9.0'/>
     </package>
     
-    <package name='SpeciesNetwork' version='0.12.2'
-            url="https://github.com/zhangchicool/speciesnetwork/releases/download/v0.12.2/SpeciesNetwork.zip"
-            description="Multispecies network coalescent (MSNC) inference of introgression and hybridization"
-            projectURL="https://github.com/zhangchicool/speciesnetwork">
-        <depends on='beast2' atleast='2.6.0' atmost='2.6.9'/>
-    </package>
     <package name='SpeciesNetwork' version='0.13.0'
             url="https://raw.githubusercontent.com/CompEvol/packages/main/SpeciesNetwork/SpeciesNetwork.zip"
             description="Multispecies network coalescent (MSNC) inference of introgression and hybridization"


### PR DESCRIPTION
I have removed unavailable version (v0.12.2) of SpeciesNetwork in packages2.6.xml.