### PR TITLE
Update packages2.7.xml

### DIFF
--- a/packages2.7.xml
+++ b/packages2.7.xml
@@ -966,6 +966,14 @@
         <depends on="BEAST.app" atleast="2.7.2"/>
     </package>
 
+    <package name="Mascot" version="3.0.6"
+         url="https://github.com/nicfel/Mascot/releases/download/v3.0.6/Mascot.v3.0.6.zip"
+         description="Marginal approximation of the structured coalescent"
+             projectURL="https://github.com/nicfel/Mascot/" >
+        <depends on="BEAST.base" atleast="2.7.2"/>
+        <depends on="BEAST.app" atleast="2.7.2"/>
+    </package>
+
     <package name="Recombination" version="1.0.0"
          url="https://github.com/nicfel/Recombination/releases/download/v1.0.0/Recombination.v1.0.0.zip"
          description="Inference of Recombination networks"


### PR DESCRIPTION
links to Mascot 3.0.6, which includes Mascot skyline