### PR TITLE
Patch release for feast.

### DIFF
--- a/packages2.7.xml
+++ b/packages2.7.xml
@@ -845,6 +845,14 @@
       <depends on="BEAST.app" atleast="2.7.0" atmost="2.7.9"/>
    </package>
 
+   <package name="feast" version="10.3.1"
+           url="https://github.com/tgvaughan/feast/releases/download/v10.3.1/feast.v10.3.1.zip"
+           projectURL="https://tgvaughan.github.io/feast"
+           description="Flexible BEAST 2 XML extension package." >
+      <depends on="BEAST.base" atleast="2.7.0" atmost="2.7.9"/>
+      <depends on="BEAST.app" atleast="2.7.0" atmost="2.7.9"/>
+   </package>
+
     <package name="ClaDS" version="2.0.0"
             url="https://bitbucket.org/bjoelle/clads/downloads/ClaDS.addon.v2.0.0.zip"
             projectURL="https://bitbucket.org/bjoelle/clads/"


### PR DESCRIPTION
This release broadens the set of exceptions caught by FeastQuery when probing BEAST objects to collect documentation. In particular, this prevents FeastQuery from crashing when the CoupledMCMC package is installed.