### PR TITLE
Add BEAST_CLASSIC 1.7.0 to packages2.8.xml

### DIFF
--- a/packages2.8.xml
+++ b/packages2.8.xml
@@ -45,4 +45,10 @@
            description="Phylodynamic simulation system" >
         <depends on="BEAST.base" atleast="2.8.0" atmost="2.8.9"/>
     </package>
+    <package name="BEAST_CLASSIC" version="1.7.0"
+        url="https://github.com/BEAST2-Dev/beast-classic/releases/download/v1.7.0-beta1/BEAST_CLASSIC.v1.7.0.zip"
+        projectURL="https://github.com/BEAST2-Dev/beast-classic"
+        description="Classic BEAST models: phylogeography, GMRF skyride, GLM">
+        <depends on="BEAST.base" atleast="2.8.0"/>
+    </package>
 </packages>


### PR DESCRIPTION
Adds the first BEAST 3 release of beast-classic (v1.7.0-beta1) to the BEAST 2.8 package repository.

## Release artifacts
- GitHub release: [v1.7.0-beta1](https://github.com/BEAST2-Dev/beast-classic/releases/tag/v1.7.0-beta1)
- Maven Central: `io.github.beast2-dev:beast-classic:1.7.0-beta1`

## Notes
- Migration: 67 classes, 9/9 tests pass. Single Maven module. Colt removed (BitVector to java.util.BitSet, DenseDoubleMatrix2D/SVD to commons-math4-legacy).
- Bug fix vs 1.6.0: TreeWithTraitLogger now logs ancestral state locations correctly ([#10](https://github.com/BEAST2-Dev/beast-classic/issues/10), merged via [PR #11](https://github.com/BEAST2-Dev/beast-classic/pull/11)).

Follows the BEASTLabs CBAN entry convention: version="1.7.0" matches version.xml; URL points to the v1.7.0-beta1 GitHub release.