### PR TITLE
Add Mascot 3.1.0 and CoupledMCMC 1.3.0 to packages2.8.xml

### DIFF
--- a/packages2.8.xml
+++ b/packages2.8.xml
@@ -51,4 +51,16 @@
         description="Classic BEAST models: phylogeography, GMRF skyride, GLM">
         <depends on="BEAST.base" atleast="2.8.0"/>
     </package>
+    <package name="Mascot" version="3.1.0"
+        url="https://github.com/CompEvol/Mascot/releases/download/v3.1.0-beta1/Mascot.v3.1.0.zip"
+        projectURL="https://github.com/CompEvol/Mascot"
+        description="Marginal approximation of the structured coalescent">
+        <depends on="BEAST.base" atleast="2.8.0"/>
+    </package>
+    <package name="CoupledMCMC" version="1.3.0"
+        url="https://github.com/CompEvol/CoupledMCMC/releases/download/v1.3.0-beta1/CoupledMCMC.v1.3.0.zip"
+        projectURL="https://github.com/CompEvol/CoupledMCMC"
+        description="Coupled MCMC (MC3) for BEAST">
+        <depends on="BEAST.base" atleast="2.8.0"/>
+    </package>
 </packages>


### PR DESCRIPTION
## Summary
- Adds Mascot 3.1.0 and CoupledMCMC 1.3.0 to the BEAST 3 package repository.
- Both repos were transferred from nicfel/ to CompEvol/. Maven Central deployments and GitHub prereleases (with ZIP assets attached) are in place:
  - https://github.com/CompEvol/Mascot/releases/tag/v3.1.0-beta1
  - https://github.com/CompEvol/CoupledMCMC/releases/tag/v1.3.0-beta1
- Each package depends only on BEAST.base 2.8.0+.

## Test plan
- [x] `xmllint --noout packages2.8.xml` passes
- [x] Asset URLs return HTTP 302 redirect to download
- [ ] `packagemanager` install resolves both ZIPs