### PR TITLE
Update phylonco release links for beast 2.6

### DIFF
--- a/packages2.6.xml
+++ b/packages2.6.xml
@@ -532,7 +532,7 @@
 	
 	
     <package name='phylonco' version='0.0.4'
-        url="https://github.com/bioDS/beast-phylonco/raw/master/dist/phylonco.addon.v0.0.4.zip"
+        url="https://github.com/bioDS/beast-phylonco/releases/download/v.0.0.4/phylonco.addon.v0.0.4.zip"
         description="A package for single cell cancer evolution"
         projectURL="https://github.com/bioDS/beast-phylonco">
         <depends on='beast2' atleast='2.6.5'/>
@@ -540,7 +540,7 @@
     </package>
 
     <package name='phylonco' version='0.0.5'
-        url="https://github.com/bioDS/beast-phylonco/raw/master/dist/phylonco.addon.v0.0.5.zip"
+        url="https://github.com/bioDS/beast-phylonco/releases/download/v0.0.5-pre/phylonco.addon.v0.0.5.zip"
         description="A package for single cell cancer evolution"
         projectURL="https://github.com/bioDS/beast-phylonco">
        <depends on='beast2' atleast='2.6.5'/>
@@ -548,7 +548,7 @@
     </package>
 
     <package name='phylonco' version='0.0.6'
-        url="https://github.com/bioDS/beast-phylonco/raw/master/dist/phylonco.addon.v0.0.6.zip"
+        url="https://github.com/bioDS/beast-phylonco/releases/download/v0.0.6/phylonco.addon.v0.0.6.zip"
         description="A package for single cell cancer evolution"
         projectURL="https://github.com/bioDS/beast-phylonco">
        <depends on='beast2' atleast='2.6.6'/>


### PR DESCRIPTION
Update links to git release version, rather than duplicate zips in `dist/`